### PR TITLE
ci: add reusable moodle workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+# .github/workflows/ci.yml
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  ci:
+    uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main
+    # secrets:
+      # Required if you plan to publish (uncomment the below)
+      # moodle_org_token: ${{ secrets.MOODLE_ORG_TOKEN }}
+    with:
+      # Not relevant
+      disable_grunt: true
+      # Not relevant
+      disable_behat: true


### PR DESCRIPTION
Based on intended ci shape:
https://github.com/catalyst/catalyst-moodle-workflows/blob/9ee004e7ded8bcb5e5ee0c90b6567293768ef011/README.md#rocket-quick-start

Resolves #7 