### PR TITLE
Moodle 4.5 bugfixes

### DIFF
--- a/classes/scanner.php
+++ b/classes/scanner.php
@@ -25,6 +25,11 @@ namespace antivirus_remote;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class scanner extends \core\antivirus\scanner {
+    /** @var string Status */
+    public $status;
+
+    /** @var string Response */
+    public $response;
 
     /**
      * Constructor to initialise class vars.

--- a/tests/fixtures/mock_curl.php
+++ b/tests/fixtures/mock_curl.php
@@ -32,6 +32,12 @@ class mock_curl extends \curl {
     /** @var int Counter for sequential calls */
     public $callcount;
 
+    /** @var string Code to respond with */
+    private $responsecode;
+
+    /** @var bool if should retry */
+    private $retrytest;
+
     /**
      * Constructor for curl mock. Handles input codes and data to return via POST.
      *

--- a/version.php
+++ b/version.php
@@ -28,3 +28,4 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->version   = 2022101100;          // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2017051500;          // Moodle 3.3+, T12+
 $plugin->component = 'antivirus_remote';   // Full name of the plugin (used for diagnostics).
+$plugin->supported = [33, 500];


### PR DESCRIPTION
**Changes**
- Adds explicit properties as dynamic properties are deprecated - Closes #16
- Add `$version->supported` to version.php so github ci runs 
